### PR TITLE
Store all websocket connections not just first and other improvements

### DIFF
--- a/static/calculator.html
+++ b/static/calculator.html
@@ -81,7 +81,11 @@
       <h1>Dashboard</h1>
       <dl>
         <dt>CO2 Emissions</dt>
-        <dd></dd>
+        <dd id="co2"></dd>
+        <dt>Number of participants</dt>
+        <dd id="n-participants"></dd>
+        <dt>Participant locations</dt>
+        <dd id="participant-locations"></dd>
       </dl>
     </section>
     <script>
@@ -131,7 +135,13 @@
         } else if (data.hasOwnProperty("calculation")) {
           sectionJoinEvent.style.display = "none";
 
-          sectionDashboard.querySelector("dd").innerHTML = data.calculation;
+          sectionDashboard.querySelector("#co2").innerHTML = data.calculation;
+          sectionDashboard.style.display = "block";
+
+          sectionDashboard.querySelector("#n-participants").innerHTML = data.event_participants;
+          sectionDashboard.style.display = "block";
+
+          sectionDashboard.querySelector("#participant-locations").innerHTML = data.participant_locations;
           sectionDashboard.style.display = "block";
         }
       }


### PR DESCRIPTION
1. Fixes that only the first websocket created was being appended to list
2. Alert all sockets for an event that there's a new participant
3. Share the location of all participants
4. Display number of participants and the locations on the page