### PR TITLE
Adding Dockerfile for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ WORKDIR /app/
 
 EXPOSE 8000
 
-CMD [ "uvicorn", "app.main:app", "--reload", "--reload-dir", "app", "--log-level", "debug", "--host", "0.0.0.0" ]
+CMD [ "uvicorn", "app.main:app", "--reload", "--reload-dir", "app", "--log-level", "info", "--host", "0.0.0.0" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.10.1
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY ./app /app/app/
+COPY ./static /app/static/
+
+WORKDIR /app/
+
+EXPOSE 8000
+
+CMD [ "uvicorn", "app.main:app", "--reload", "--reload-dir", "app", "--log-level", "debug", "--host", "0.0.0.0" ]

--- a/README.md
+++ b/README.md
@@ -16,11 +16,6 @@ Run the local development server:
 uvicorn app.main:app --reload --reload-dir app --log-level debug
 ```
 
-To start the development database:
-
-```bash
-docker-compose up postgres
-```
 
 ## Deployment
 
@@ -28,4 +23,24 @@ The API is hosted on Heroku at [co2-calculator-api.herokuapp.com](https://co2-ca
 
 ```api
 git push https://git.heroku.com/co2-calculator-api.git main
+```
+
+## Using Docker
+
+To build the application container, use
+
+```bash
+docker build . -t co2-calculator-api
+```
+
+You can then start the container and the development database using
+
+```bash
+docker compose up -d
+```
+
+Alternatively, you can also run locally and use a Docker container only for the development database:
+
+```bash
+docker-compose up postgres
 ```

--- a/README.md
+++ b/README.md
@@ -2,29 +2,6 @@
 
 ## Local Development
 
-The project runs with *Python 3.10.1*.
-
-Install packages:
-
-```bash
-pip install -r requirements.txt
-```
-
-Run the local development server:
-
-```bash
-uvicorn app.main:app --reload --reload-dir app --log-level debug
-```
-
-
-## Deployment
-
-The API is hosted on Heroku at [co2-calculator-api.herokuapp.com](https://co2-calculator-api.herokuapp.com/)
-
-```api
-git push https://git.heroku.com/co2-calculator-api.git main
-```
-
 ## Using Docker
 
 To build the application container, use
@@ -39,8 +16,26 @@ You can then start the container and the development database using
 docker compose up -d
 ```
 
-Alternatively, you can also run locally and use a Docker container only for the development database:
+### Using Locally installed Python and Postgres
+
+The project runs with *Python 3.10.1*.
+
+Install packages:
 
 ```bash
-docker-compose up postgres
+pip install -r requirements.txt
+```
+
+Run the local development server:
+
+```bash
+uvicorn app.main:app --reload --reload-dir app --log-level debug
+```
+
+## Deployment
+
+The API is hosted on Heroku at [co2-calculator-api.herokuapp.com](https://co2-calculator-api.herokuapp.com/)
+
+```api
+git push https://git.heroku.com/co2-calculator-api.git main
 ```

--- a/README.md
+++ b/README.md
@@ -10,10 +10,16 @@ To build the application container, use
 docker build . -t co2-calculator-api
 ```
 
-You can then start the container and the development database using
+You can then start the app and database containers using:
 
 ```bash
-docker compose up -d
+docker compose up --detach
+```
+
+Or just start the database using:
+
+```bash
+docker-compose up --detach database
 ```
 
 ### Using Locally installed Python and Postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,9 @@
 version: '3.7'
 services:
+    co2-calculator-api:
+      image: co2-calculator-api:latest
+      ports:
+        - '8000:8000/tcp'
     postgres:
         image: postgres:10.5
         restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
 version: '3.7'
 services:
-    co2-calculator-api:
+    app:
       image: co2-calculator-api:latest
       ports:
         - '8000:8000/tcp'
-    postgres:
-        image: postgres:10.5
+      volumes:
+        - ./:/app
+    database:
+        image: postgres:13.5
         restart: always
         environment:
           - POSTGRES_USER=postgres
@@ -18,4 +20,6 @@ services:
         ports:
           - '5432:5432'
         volumes:
-          - ./postgres-data:/var/lib/postgresql/data
+          - postgres-data:/var/lib/postgresql/data
+volumes:
+  postgres-data:


### PR DESCRIPTION
Adding Dockerfile for local development. See README for usage.

Note: this supposes that we have default settings that don't require the presence of a `.env` file. `docker compose` breaks when the `.env` file contains the JSON string for `CORS_ORIGINS`. @F-Ruxton is addressing this by adding default settings.

Meanwhile, should you want to run locally without default settings, apply this patch to your docker-compose.yml

```
diff --git a/docker-compose.yml b/docker-compose.yml
index 9420df1..616c298 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,14 @@ version: '3.7'
 services:
     co2-calculator-api:
       image: co2-calculator-api:latest
+      environment:
+        - PROJECT_NAME=co2-calculator-api
+        - SERVER_HOST=http://localhost:8000
+        - 'CORS_ORIGINS=["http://localhost", "https://localhost", "http://localhost:8000", "https://localhost:8000"]'
+        - POSTGRES_USER=postgres
+        - POSTGRES_PASSWORD=postgres
+        - POSTGRES_SERVER=localhost:5432
+        - POSTGRES_DB=postgres
       ports:
         - '8000:8000/tcp'
     postgres:
```